### PR TITLE
Increasing Camera Resolution

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -98,11 +98,7 @@ public class Robot extends TimedRobot {
   public void robotInit() {
 
     UsbCamera m_camera = CameraServer.getInstance().startAutomaticCapture(kUsbCameraChannel);
-    m_camera.setResolution(240, 180);
-    //try increasing camera resolution
-    //m_camera.setResolution(352, 240);
-
-    //m_camera.setVideoMode(VideoMode.PixelFormat.kYUYV,320,180,30);
+    m_camera.setVideoMode(VideoMode.PixelFormat.kYUYV,640,480,30);
 
     
     WPI_TalonSRX frontLeftWPI_TalonSRX = new WPI_TalonSRX(kFrontLeftChannel);


### PR DESCRIPTION
A higher resolution would be more beneficial to the driver. The proposed change gives video with a resolution of 640x480 with 30fps. The setResolution method is not needed if this is used. If the resolution can be increased more, the maximum resolution of the camera is 1280x720.